### PR TITLE
ページ遷移実装

### DIFF
--- a/hack-viewer/src/App.js
+++ b/hack-viewer/src/App.js
@@ -1,15 +1,11 @@
 import { CssBaseline } from "@mui/material";
-import EventPage from "./components/pages/EventPage";
-import HomePage from "./components/pages/HomePage";
-import SettingPage from "./components/pages/TeamSetting";
+import MainRouter from "./components/router/MainRouter"
 
 function App() {
   return (
     <>
       <CssBaseline></CssBaseline>
-      <HomePage/>
-      <EventPage/>
-      <SettingPage/>
+      <MainRouter></MainRouter>
     </>
   );
 }

--- a/hack-viewer/src/components/pages/ErrorPage.jsx
+++ b/hack-viewer/src/components/pages/ErrorPage.jsx
@@ -1,0 +1,17 @@
+import { Box } from "@mui/material";
+import MainTitle from "../organisms/MainTitle";
+import MainLayout from "../templates/MainLayout";
+
+const ErrorPage = () => {
+    return(
+        <MainLayout>
+            <Box>
+                <MainTitle>
+                    お探しのページが見つかりませんでした。
+                </MainTitle>
+            </Box>
+        </MainLayout>
+    )
+}
+
+export default ErrorPage;

--- a/hack-viewer/src/components/router/MainRouter.jsx
+++ b/hack-viewer/src/components/router/MainRouter.jsx
@@ -1,0 +1,20 @@
+import { BrowserRouter, Routes, Route} from "react-router-dom";
+import Errorpage from "../pages/ErrorPage";
+import EventPage from "../pages/EventPage";
+import HomePage from "../pages/HomePage";
+import TeamSettingPage from "../pages/TeamSetting";
+
+const MainRouter = () => {
+    return(
+        <BrowserRouter>
+            <Routes>
+                <Route path={"/"} element={<HomePage/>}/>
+                <Route path={"/Event"} element={<EventPage/>}/>
+                <Route path={"/TeamSetting"} element={<TeamSettingPage/>}/>
+                <Route path={`/*`} element={<Errorpage/>} />
+            </Routes>
+        </BrowserRouter>
+    )
+}
+
+export default MainRouter;


### PR DESCRIPTION
- ４ページ分（home・event・teamSetting・ErrorPage）の画面遷移
- エラーページ（ErrorPage）の作成
- ルーティングがない場合のエラーページへの遷移